### PR TITLE
Updating dependencies to fix vulnerability issues:

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>xalan</groupId>
             <artifactId>xalan</artifactId>
-            <version>2.7.2</version>
+            <version>2.7.3</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.sonar-plugins.xml</groupId>
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.mockito/mockito-all -->


### PR DESCRIPTION
Bump junit:junit from 4.11 to 4.13.1
Bumps xalan:xalan from 2.7.2 to 2.7.3.