### PR TITLE
Fix 2.0.1 deploy (GitHub Packages owner)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
         run: |
           docker run --rm \
             -v ${{ github.workspace }}:/workspace \
-            registry.gitlab.com/haynes/jacoco2cobertura:1.0.9 \
+            registry.gitlab.com/haynes/jacoco2cobertura:latest \
             python /opt/cover2cover.py /workspace/target/site/jacoco/jacoco.xml /workspace/src/main/java/ > ${{ github.workspace }}/target/site/cobertura.xml
 
       - name: Upload coverage report

--- a/pom.xml
+++ b/pom.xml
@@ -61,11 +61,11 @@
     <distributionManagement>
         <repository>
             <id>github</id>
-            <url>https://maven.pkg.github.com/tibco/sonar-bw</url>
+            <url>https://maven.pkg.github.com/TIBCOSoftware/sonar-bw</url>
         </repository>
         <snapshotRepository>
             <id>github</id>
-            <url>https://maven.pkg.github.com/tibco/sonar-bw</url>
+            <url>https://maven.pkg.github.com/TIBCOSoftware/sonar-bw</url>
         </snapshotRepository>
     </distributionManagement>
 


### PR DESCRIPTION
Follow-up to #25 to make the 2.0.1 release deployable.

Fixes two issues found after merging #25:

- **Deploy**: `distributionManagement` still pointed at the old
  `maven.pkg.github.com/tibco/sonar-bw` owner after the repository moved to
  `TIBCOSoftware`, so `mvn deploy` failed to publish 2.0.1. Both URLs now use
  the current owner.
- **visualize job**: pin `jacoco2cobertura` to the `latest` tag (the previous
  `1.0.9` tag was unpublished).

Merging this re-runs the `main` pipeline and publishes 2.0.1 to GitHub Packages.
