### PR TITLE
Make vulnerability check non-blocking for releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,19 +123,6 @@ jobs:
           else
             mvn $MAVEN_CLI_OPTS versions:set -DgenerateBackupPoms=false -DnewVersion=${{ steps.project.outputs.version }}-SNAPSHOT
           fi
-      - name: Vulnerability Check
-        id: check
-        run: |
-          if [[ "${GITHUB_REF_NAME}" == "main" ]] || [[ "${GITHUB_REF_NAME}" =~ "release/" ]]; then
-            # Use the NVD API key when configured to avoid the slow, rate-limited
-            # anonymous NVD download; falls back to anonymous if the secret is unset.
-            KEY_ARG=""
-            [ -n "$NVD_API_KEY" ] && KEY_ARG="-DnvdApiKey=$NVD_API_KEY"
-            mvn $MAVEN_CLI_OPTS org.owasp:dependency-check-maven:10.0.3:check $KEY_ARG
-          fi
-        env:
-          MAVEN_OPTS: ${{ secrets.MAVEN_OPTS }}
-          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
 
       - name: Deploy with maven with Maven
         run: |
@@ -145,6 +132,57 @@ jobs:
         env:
           MAVEN_OPTS: ${{ secrets.MAVEN_OPTS }}
 
+
+  # Runs independently of `deploy` so a slow or unavailable NVD service never
+  # blocks a release. Only executes on main / release branches.
+  vulnerability-check:
+    runs-on: ubuntu-latest
+    needs: test
+    if: github.ref_name == 'main' || startsWith(github.ref_name, 'release/')
+    timeout-minutes: 30
+    env:
+      MAVEN_CLI_OPTS: "-s ci_settings.xml"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Cache Maven local repository
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven
+
+      # Rolling cache of the NVD database: a unique key always saves a fresh
+      # copy, restore-keys brings back the latest one so updates stay incremental.
+      - name: Cache NVD database
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository/org/owasp/dependency-check-data
+          key: nvd-data-${{ github.run_id }}
+          restore-keys: nvd-data-
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+
+      - name: OWASP dependency-check
+        run: |
+          KEY_ARG=""
+          [ -n "$NVD_API_KEY" ] && KEY_ARG="-DnvdApiKey=$NVD_API_KEY"
+          mvn $MAVEN_CLI_OPTS org.owasp:dependency-check-maven:10.0.3:check $KEY_ARG
+        env:
+          MAVEN_OPTS: ${{ secrets.MAVEN_OPTS }}
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+
+      - name: Upload dependency-check report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dependency-check-report
+          path: target/dependency-check-report.*
 
   visualize:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Deploy no longer waits on the OWASP dependency-check / NVD download. The check runs in its own job (main/release only) with NVD caching and a 30-min timeout, so 2.0.1 can publish without being blocked by NVD outages.