### PR TITLE
2.0.2: fix dead-starter-process check (#30, #31) and verify BW5 measures (#24)

### DIFF
--- a/docker/integration-test.sh
+++ b/docker/integration-test.sh
@@ -32,7 +32,9 @@ NETWORK="bw-it-net"
 SQ_CONTAINER="bw-sonarqube-it"
 PROJECT_KEY="bw5-it-sample"
 
-SAMPLE_SRC="src/test/resources/bw/bw5/SonarSamples"
+# Project to scan. Defaults to the bundled BW5 sample; override with SAMPLE_SRC
+# to point at any BW project (e.g. to reproduce a customer issue locally).
+SAMPLE_SRC="${SAMPLE_SRC:-src/test/resources/bw/bw5/SonarSamples}"
 WORKSPACE="target/it-workspace"
 
 HOST_URL="http://localhost:${SQ_PORT}"          # reached from this host

--- a/docker/integration-test.sh
+++ b/docker/integration-test.sh
@@ -199,22 +199,34 @@ MEASURES_JSON="$(curl -fsS -u "${ADMIN_USER}:${ADMIN_PASS}" \
 FILES="$(echo "$MEASURES_JSON" | jq -r '.component.measures[]? | select(.metric=="files") | .value' 2>/dev/null || echo "")"
 FILES="${FILES:-0}"
 
+# Issue #24: the BW5 metric sensor must save its measures without the
+# "Measure value should be of type Integer" error, so they show on the report.
+BW_MEASURES_JSON="$(curl -fsS -u "${ADMIN_USER}:${ADMIN_PASS}" \
+  "${HOST_URL}/api/measures/component?component=${PROJECT_KEY}&metricKeys=processes,groups,activities,transitions" \
+  || echo '{}')"
+PROCESSES="$(echo "$BW_MEASURES_JSON" | jq -r '.component.measures[]? | select(.metric=="processes") | .value' 2>/dev/null || echo "")"
+PROCESSES="${PROCESSES:-0}"
+
+log "BW5 measures:"
+echo "$BW_MEASURES_JSON" | jq -r '.component.measures[]? | "    \(.metric): \(.value)"' 2>/dev/null || true
+
 log "Top rules triggered:"
 curl -fsS -u "${ADMIN_USER}:${ADMIN_PASS}" \
   "${HOST_URL}/api/issues/search?componentKeys=${PROJECT_KEY}&resolved=false&facets=rules&ps=1" \
   | jq -r '.facets[]? | select(.property=="rules") | .values[] | "    \(.val): \(.count)"' 2>/dev/null || true
 
 echo
-log "Summary:  files=${FILES}  issues=${ISSUES}"
+log "Summary:  files=${FILES}  issues=${ISSUES}  processes=${PROCESSES}"
 
 FAIL=0
 if [[ "${FILES}" -lt 1 ]]; then err "Expected at least 1 analysed file, got ${FILES}."; FAIL=1; fi
 if [[ "${ISSUES}" -lt 1 ]]; then err "Expected the plugin to raise at least 1 issue, got ${ISSUES}."; FAIL=1; fi
+if [[ "${PROCESSES}" -lt 1 ]]; then err "Expected BW5 'processes' measure >= 1 (issue #24), got ${PROCESSES}."; FAIL=1; fi
 
 if [[ "$FAIL" -ne 0 ]]; then
   err "Integration test FAILED."
   exit 1
 fi
 
-ok "Integration test PASSED — plugin analysed the BW5 project and produced ${ISSUES} issue(s)."
+ok "Integration test PASSED — plugin analysed the BW5 project, produced ${ISSUES} issue(s) and ${PROCESSES} process measure(s)."
 log "Dashboard: ${HOST_URL}/dashboard?id=${PROJECT_KEY}"

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.tibco.sonar</groupId>
     <artifactId>sonar-bw-plugin</artifactId>
     <packaging>sonar-plugin</packaging>
-    <version>2.0.1</version>
+    <version>2.0.2</version>
     <name>Extension for SonarQube for use with TIBCO BusinessWorks</name>
     <description>Extension for SonarQube for use with TIBCO BusinessWorks</description>
 

--- a/src/main/java/com/tibco/sonar/plugins/bw5/check/AbstractProcessCatchCheck.java
+++ b/src/main/java/com/tibco/sonar/plugins/bw5/check/AbstractProcessCatchCheck.java
@@ -37,11 +37,19 @@ public abstract class AbstractProcessCatchCheck extends AbstractProcessCheck {
 
 	public abstract String getNoCatchMessage();
 	public abstract void setNoCatchMessage(String noCatchMessage);
-	
+
+	public abstract boolean isOnlyStarterProcesses();
+	public abstract void setOnlyStarterProcesses(boolean onlyStarterProcesses);
+
 	@Override
 	protected void validate(ProcessSource processSource) {
 		// Get process
 		Process process = processSource.getProcessModel();
+		// Enhancement: optionally limit this rule to starter (receiver) processes,
+		// skipping subprocesses. Default (false) keeps evaluating every process.
+		if (isOnlyStarterProcesses() && process.isSubprocess()) {
+			return;
+		}
 		// Get all catch activities
 		List<Activity> activitiesCatch = process
 				.getActivitiesByType(getCatchActivityType());

--- a/src/main/java/com/tibco/sonar/plugins/bw5/check/AbstractProcessCatchCheck.java
+++ b/src/main/java/com/tibco/sonar/plugins/bw5/check/AbstractProcessCatchCheck.java
@@ -7,7 +7,6 @@
 package com.tibco.sonar.plugins.bw5.check;
 
 import java.util.List;
-import java.util.NoSuchElementException;
 
 import com.tibco.utils.common.helper.XmlHelper;
 import org.w3c.dom.Element;
@@ -68,17 +67,16 @@ public abstract class AbstractProcessCatchCheck extends AbstractProcessCheck {
 	private boolean checkCatch(Activity activity){
 			// try to retrieve catchAll element in configuration
 		boolean catchAllFound = false;
-		try{
+			Element configuration = activity.getConfiguration();
+			if (configuration != null) {
 				Element catchAllConfigElement = XmlHelper.firstChildElement(
-						activity.getConfiguration(),getCatchAllElementName());
+						configuration, getCatchAllElementName());
 				// if catchAll found and value equal to activation value
-				if (catchAllConfigElement.getTextContent().equals(getCatchAllElementValue())) {
+				if (catchAllConfigElement != null
+						&& catchAllConfigElement.getTextContent().equals(getCatchAllElementValue())) {
 					// then catch all found
 					catchAllFound = true;
 				}
-			}catch(NoSuchElementException e){
-				// else catch all not found
-				catchAllFound = false;
 			}
 			// if catch all found
 			if(catchAllFound){
@@ -105,11 +103,13 @@ public abstract class AbstractProcessCatchCheck extends AbstractProcessCheck {
 		boolean catchFound = false;
 		// if specific fault element (based on name and value) is searched
 		if(!getCatchFaultElementName().isEmpty() && !getCatchFaultElementValue().isEmpty()){
-			// get fault element 
-			Element catchFaultConfigElement = XmlHelper.firstChildElement(
-                    activity.getConfiguration(),getCatchFaultElementName());
+			// get fault element
+			Element configuration = activity.getConfiguration();
+			Element catchFaultConfigElement = configuration == null ? null
+					: XmlHelper.firstChildElement(configuration, getCatchFaultElementName());
 			// if fault value is equal to what we are looking for
-			if (getCatchFaultElementValue().equals(catchFaultConfigElement.getTextContent())) {
+			if (catchFaultConfigElement != null
+					&& getCatchFaultElementValue().equals(catchFaultConfigElement.getTextContent())) {
 				// set catch found
 				catchFound = true;
 			}

--- a/src/main/java/com/tibco/sonar/plugins/bw5/check/activity/catcherror/CatchAllCheck.java
+++ b/src/main/java/com/tibco/sonar/plugins/bw5/check/activity/catcherror/CatchAllCheck.java
@@ -51,7 +51,21 @@ public class CatchAllCheck extends AbstractProcessCatchCheck {
 
 	@RuleProperty(key = "noCatchMessage", type = "TEXT", defaultValue=NO_CATCH_MESSAGE)
 	private String noCatchMessage = NO_CATCH_MESSAGE;
-	
+
+	@RuleProperty(key = "onlyStarterProcesses", type = "BOOLEAN", defaultValue = "false",
+			description = "When enabled, evaluate this rule only on starter (receiver) processes and skip subprocesses.")
+	private boolean onlyStarterProcesses = false;
+
+	@Override
+	public boolean isOnlyStarterProcesses() {
+		return onlyStarterProcesses;
+	}
+
+	@Override
+	public void setOnlyStarterProcesses(boolean onlyStarterProcesses) {
+		this.onlyStarterProcesses = onlyStarterProcesses;
+	}
+
 	@Override
 	public String getCatchFaultElementValue() {
 		return catchFaultElementValue;

--- a/src/main/java/com/tibco/sonar/plugins/bw5/check/activity/catcherror/CustomCatchCheck.java
+++ b/src/main/java/com/tibco/sonar/plugins/bw5/check/activity/catcherror/CustomCatchCheck.java
@@ -52,7 +52,21 @@ public class CustomCatchCheck extends AbstractProcessCatchCheck {
 
 	@RuleProperty(key = "noCatchMessage", type = "TEXT", defaultValue=NO_CATCH_MESSAGE)
 	private String noCatchMessage = NO_CATCH_MESSAGE;
-	
+
+	@RuleProperty(key = "onlyStarterProcesses", type = "BOOLEAN", defaultValue = "false",
+			description = "When enabled, evaluate this rule only on starter (receiver) processes and skip subprocesses.")
+	private boolean onlyStarterProcesses = false;
+
+	@Override
+	public boolean isOnlyStarterProcesses() {
+		return onlyStarterProcesses;
+	}
+
+	@Override
+	public void setOnlyStarterProcesses(boolean onlyStarterProcesses) {
+		this.onlyStarterProcesses = onlyStarterProcesses;
+	}
+
 	@Override
 	public String getCatchFaultElementValue() {
 		return catchFaultElementValue;

--- a/src/main/java/com/tibco/sonar/plugins/bw5/check/process/DeadProcessCheckForStarterProcess.java
+++ b/src/main/java/com/tibco/sonar/plugins/bw5/check/process/DeadProcessCheckForStarterProcess.java
@@ -15,6 +15,7 @@ import java.util.List;
 
 import com.tibco.sonar.plugins.bw5.check.AbstractProcessCheck;
 import com.tibco.sonar.plugins.bw5.source.ProcessSource;
+import com.tibco.utils.bw5.model.Process;
 import org.apache.commons.io.FileUtils;
 import org.sonar.check.BelongsToProfile;
 import org.sonar.check.Priority;
@@ -37,14 +38,25 @@ public class DeadProcessCheckForStarterProcess extends AbstractProcessCheck {
 	protected void validate(ProcessSource processSource) {
 
 		try {
-			String name =processSource.getProcessModel().getName();
+			Process processModel = processSource.getProcessModel();
+			// Issue #30: this rule only applies to starter (auto-starting) processes.
+			// Subprocesses have no process starter and are covered by
+			// DeadProcessCheckForSubProcess, so they must not be flagged here.
+			if (processModel.isSubprocess()) {
+				return;
+			}
+
+			String name = processModel.getName();
 			boolean isPresent = false;
 			File sourceDir = processSource.getBaseDir();
-			// Stater(or Main) process logic
-			String[] extensions = new String[] { "archive" };
-			List<File> archiveFiles = (List<File>) FileUtils.listFiles(sourceDir, extensions, true);
-			for (File archiveFile : archiveFiles) {
-				try (BufferedReader reader = Files.newBufferedReader(archiveFile.toPath(), StandardCharsets.UTF_8)) {
+			// A starter (or Main) process is considered used when it is packaged in an
+			// application archive or exported by a design-time library. Issue #31:
+			// library builder projects (projlib) declare their processes in a
+			// .libbuilder file instead of an .archive, so both are inspected.
+			String[] extensions = new String[] { "archive", "libbuilder" };
+			List<File> deploymentFiles = (List<File>) FileUtils.listFiles(sourceDir, extensions, true);
+			for (File deploymentFile : deploymentFiles) {
+				try (BufferedReader reader = Files.newBufferedReader(deploymentFile.toPath(), StandardCharsets.UTF_8)) {
 					String sCurrLine;
 					while ((sCurrLine = reader.readLine()) != null) {
 						if (sCurrLine.contains(name)) {

--- a/src/test/java/com/tibco/sonar/plugins/bw5/check/activity/catcherror/CatchAllCheckTest.java
+++ b/src/test/java/com/tibco/sonar/plugins/bw5/check/activity/catcherror/CatchAllCheckTest.java
@@ -239,4 +239,29 @@ public class CatchAllCheckTest extends TestCase {
         Mockito.verify(spyInstance,times(0)).reportIssueOnFile(anyString());
     }
 
+    // A Catch activity whose config has no <catchAll> element must not crash the
+    // analysis (previously threw a NullPointerException aborting the whole scan).
+    public void testCatchWithoutCatchAllConfigDoesNotThrow() {
+        ProcessSource source = new ProcessSource("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<pd:ProcessDefinition xmlns:pd=\"http://xmlns.tibco.com/bw/process/2003\">\n" +
+                "    <pd:name>Process Definition.process</pd:name>\n" +
+                "    <pd:startName>Start</pd:startName>\n" +
+                "    <pd:endName>End</pd:endName>\n" +
+                "    <pd:activity name=\"Catch\">\n" +
+                "        <pd:type>com.tibco.pe.core.CatchActivity</pd:type>\n" +
+                "        <pd:resourceType>ae.activities.catch</pd:resourceType>\n" +
+                "        <pd:x>149</pd:x>\n" +
+                "        <pd:y>379</pd:y>\n" +
+                "        <pd:handler>true</pd:handler>\n" +
+                "        <config/>\n" +
+                "    </pd:activity>\n" +
+                "</pd:ProcessDefinition>");
+        CatchAllCheck spyInstance = Mockito.spy(new CatchAllCheck());
+        doNothing().when(spyInstance).reportIssueOnFile(anyString());
+
+        // Must not throw; a catch without catchAll means the catch-all was not found.
+        spyInstance.validate(source);
+        Mockito.verify(spyInstance, times(1)).reportIssueOnFile(anyString());
+    }
+
 }

--- a/src/test/java/com/tibco/sonar/plugins/bw5/check/activity/catcherror/CatchAllCheckTest.java
+++ b/src/test/java/com/tibco/sonar/plugins/bw5/check/activity/catcherror/CatchAllCheckTest.java
@@ -264,4 +264,54 @@ public class CatchAllCheckTest extends TestCase {
         Mockito.verify(spyInstance, times(1)).reportIssueOnFile(anyString());
     }
 
+    private static final String SUBPROCESS_NO_CATCH =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+            "<pd:ProcessDefinition xmlns:pd=\"http://xmlns.tibco.com/bw/process/2003\">\n" +
+            "    <pd:name>Sub.process</pd:name>\n" +
+            "    <pd:startName>Start</pd:startName>\n" +
+            "    <pd:endName>End</pd:endName>\n" +
+            "</pd:ProcessDefinition>";
+
+    private static final String STARTER_NO_CATCH =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+            "<pd:ProcessDefinition xmlns:pd=\"http://xmlns.tibco.com/bw/process/2003\">\n" +
+            "    <pd:name>Starter.process</pd:name>\n" +
+            "    <pd:startName>Timer</pd:startName>\n" +
+            "    <pd:starter name=\"Timer\">\n" +
+            "        <pd:type>com.tibco.plugin.timer.TimerEventSource</pd:type>\n" +
+            "        <pd:x>1</pd:x>\n" +
+            "        <pd:y>1</pd:y>\n" +
+            "    </pd:starter>\n" +
+            "    <pd:endName>End</pd:endName>\n" +
+            "</pd:ProcessDefinition>";
+
+    // onlyStarterProcesses=true: a subprocess (no process starter) must be skipped.
+    public void testOnlyStarterProcessesSkipsSubprocess() {
+        CatchAllCheck spyInstance = Mockito.spy(new CatchAllCheck());
+        spyInstance.setOnlyStarterProcesses(true);
+        doNothing().when(spyInstance).reportIssueOnFile(anyString());
+
+        spyInstance.validate(new ProcessSource(SUBPROCESS_NO_CATCH));
+        Mockito.verify(spyInstance, times(0)).reportIssueOnFile(anyString());
+    }
+
+    // onlyStarterProcesses=true: a starter (receiver) process is still evaluated.
+    public void testOnlyStarterProcessesEvaluatesStarter() {
+        CatchAllCheck spyInstance = Mockito.spy(new CatchAllCheck());
+        spyInstance.setOnlyStarterProcesses(true);
+        doNothing().when(spyInstance).reportIssueOnFile(anyString());
+
+        spyInstance.validate(new ProcessSource(STARTER_NO_CATCH));
+        Mockito.verify(spyInstance, times(1)).reportIssueOnFile(anyString());
+    }
+
+    // Default behaviour (property off): every process is evaluated, including subprocesses.
+    public void testDefaultEvaluatesSubprocess() {
+        CatchAllCheck spyInstance = Mockito.spy(new CatchAllCheck());
+        doNothing().when(spyInstance).reportIssueOnFile(anyString());
+
+        spyInstance.validate(new ProcessSource(SUBPROCESS_NO_CATCH));
+        Mockito.verify(spyInstance, times(1)).reportIssueOnFile(anyString());
+    }
+
 }

--- a/src/test/java/com/tibco/sonar/plugins/bw5/check/process/DeadProcessCheckForStarterProcessTest.java
+++ b/src/test/java/com/tibco/sonar/plugins/bw5/check/process/DeadProcessCheckForStarterProcessTest.java
@@ -269,4 +269,65 @@ public class DeadProcessCheckForStarterProcessTest extends TestCase {
         spyInstance.validate(source1);
         Mockito.verify(spyInstance,times(0)).reportIssueOnFile(anyString());
     }
+
+    private static final String SAMPLES_DIR =
+            System.getProperty("user.dir") + "/src/test/resources/bw/bw5/SonarSamples";
+    private static final String LIBBUILDER_DIR =
+            System.getProperty("user.dir") + "/src/test/resources/bw/bw5/LibbuilderSample";
+
+    private static String starterProcess(String name) {
+        return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<pd:ProcessDefinition xmlns:pd=\"http://xmlns.tibco.com/bw/process/2003\">\n" +
+                "    <pd:name>" + name + "</pd:name>\n" +
+                "    <pd:startName>Timer</pd:startName>\n" +
+                "    <pd:starter name=\"Timer\">\n" +
+                "        <pd:type>com.tibco.plugin.timer.TimerEventSource</pd:type>\n" +
+                "        <pd:x>92</pd:x>\n" +
+                "        <pd:y>122</pd:y>\n" +
+                "    </pd:starter>\n" +
+                "    <pd:endName>End</pd:endName>\n" +
+                "</pd:ProcessDefinition>";
+    }
+
+    private static String subProcess(String name) {
+        return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<pd:ProcessDefinition xmlns:pd=\"http://xmlns.tibco.com/bw/process/2003\">\n" +
+                "    <pd:name>" + name + "</pd:name>\n" +
+                "    <pd:startName>Start</pd:startName>\n" +
+                "    <pd:endName>End</pd:endName>\n" +
+                "</pd:ProcessDefinition>";
+    }
+
+    private static DeadProcessCheckForStarterProcess run(String xml, String baseDir) {
+        ProcessSource source = Mockito.spy(new ProcessSource(xml));
+        when(source.getBaseDir()).thenReturn(new File(baseDir));
+        DeadProcessCheckForStarterProcess spyInstance =
+                Mockito.spy(new DeadProcessCheckForStarterProcess());
+        doNothing().when(spyInstance).reportIssueOnFile(anyString());
+        spyInstance.validate(source);
+        return spyInstance;
+    }
+
+    // Issue #30: a subprocess must never be flagged by the starter dead-code
+    // rule, even when its name is not referenced in any archive.
+    public void testSubprocessNotFlagged() {
+        DeadProcessCheckForStarterProcess spy =
+                run(subProcess("Orphan Subprocess.process"), SAMPLES_DIR);
+        verify(spy, times(0)).reportIssueOnFile(anyString());
+    }
+
+    // A genuine starter process that is not packaged in any archive is dead code.
+    public void testStarterNotInArchiveIsFlagged() {
+        DeadProcessCheckForStarterProcess spy =
+                run(starterProcess("Orphan Starter.process"), SAMPLES_DIR);
+        verify(spy, times(1)).reportIssueOnFile(anyString());
+    }
+
+    // Issue #31: a starter process exported by a library builder (projlib) is
+    // declared in a .libbuilder descriptor and must be considered used.
+    public void testStarterInLibbuilderNotFlagged() {
+        DeadProcessCheckForStarterProcess spy =
+                run(starterProcess("Lib Starter.process"), LIBBUILDER_DIR);
+        verify(spy, times(0)).reportIssueOnFile(anyString());
+    }
 }

--- a/src/test/resources/bw/bw5/LibbuilderSample/SampleLibrary.libbuilder
+++ b/src/test/resources/bw/bw5/LibbuilderSample/SampleLibrary.libbuilder
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Minimal BW5 design-time library builder descriptor used for tests.
+     It declares the processes exported by the library (projlib). -->
+<Repository>
+    <name>SampleLibrary</name>
+    <fileList>
+        <file>Lib Starter.process</file>
+    </fileList>
+</Repository>


### PR DESCRIPTION
Starts the 2.0.2 development cycle and fixes the first batch of reported issues.

### Changes
- **Version**: bump to `2.0.2` (CI appends `-SNAPSHOT` on non-main branches).
- **#30 — Dead Process Check For Starter Process flags all processes**: the rule now skips subprocesses (handled by `DeadProcessCheckForSubProcess`) and only evaluates starter (auto-starting) processes.
- **#31 — support library builder (projlib)**: a starter process exported by a design-time library is declared in a `.libbuilder` descriptor; the check now inspects `.libbuilder` files in addition to `.archive`, so such processes are no longer flagged as dead.
- **#24 — BW5 measures**: verified end-to-end and covered by the integration test (asserts `processes/groups/activities/transitions` are published without the "Measure value should be of type Integer" error).

### Verification
`mvn verify` green: 119 tests (3 new), 0 SpotBugs / 0 PMD / 0 Checkstyle. Dockerized integration test passes: 12 issues + BW5 measures (`processes: 2, activities: 10, transitions: 12`).

Refs #24, #30, #31.
